### PR TITLE
[Misc] Fix make init failure by adding --system flag to uv pip install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ init:
 			echo "Installing uv..."; \
 			curl -LsSf https://astral.sh/uv/install.sh | sh; \
 		fi; \
-		uv pip install --system pre-commit; \
+		pip install pre-commit;\
 		pre-commit install; \
 		echo "Note: CUDA Toolkit is not officially supported on macOS."; \
 		echo "For CUDA development, please use Docker or a Linux environment."; \
@@ -58,7 +58,7 @@ init:
 		apt-get install -y \
 		gdb cuda-toolkit-12-6 \
 		clang-tidy clang-format; \
-		uv pip install --system pre-commit; \
+		pip install pre-commit; \
 		pre-commit install; \
 	else \
 		echo "Error: Unsupported OS ($(UNAME_S))"; \


### PR DESCRIPTION
<!-- markdownlint-disable -->
## 🎯 Purpose

This PR fixes an issue where make init fails on systems using uv without an active virtual environment.

Closes: #6 


## 🧩 Component


## 📝 Implementation Summary

<!-- Brief overview of what you implemented and how -->


## 🧪 Testing

<!-- How did you test your changes? -->

```bash
# Build and test commands
make init
```

**Test Results:**
<!-- Paste test output, benchmark results, or screenshots -->


## 📚 Documentation

<!-- Did you update documentation? -->


## 👥 Review Notes

<!-- Any specific areas reviewers should focus on? -->


---

**Reviewers:** Please check the implementation carefully and test the changes if possible.

