### PR TITLE
[CI] Resolve duplicate variable declaration in issue autolabel workflow

### DIFF
--- a/.github/workflows/issue_autolabel.yml
+++ b/.github/workflows/issue_autolabel.yml
@@ -278,7 +278,6 @@ jobs:
             
             const assignees = context.payload.issue.assignees || [];
             const assignedUsernames = assignees.map(a => a.login);
-            const existingLabels = context.payload.issue.labels.map(l => l.name);
             
             // Check if assignee labels exist in repository
             const { data: repoLabels } = await github.rest.issues.listLabelsForRepo({


### PR DESCRIPTION
## 🎯 Purpose

Fix SyntaxError in the issue autolabel GitHub Actions workflow caused by duplicate variable declaration.

Closes: #29


## 🧩 Component

CI/CD - GitHub Actions workflow


## 📝 Implementation Summary

Fixed a JavaScript SyntaxError in `.github/workflows/issue_autolabel.yml` where the `existingLabels` variable was declared twice:
- First declaration at line 250 (after keyword-based label processing)
- Duplicate declaration at line 281 (in assignee-based labeling section)

Removed the duplicate declaration on line 281 since the variable from line 250 can be reused throughout the script scope.


## 🧪 Testing

The workflow will be tested automatically when:
- Issues are opened, edited, reopened, assigned, or unassigned
- This PR can be tested by triggering the workflow on test issues

**Expected behavior:**
- Workflow runs without SyntaxError
- Labels are correctly added/removed based on keywords and assignees


## 📚 Documentation

No documentation updates needed - this is a bug fix for existing functionality.


## 👥 Review Notes

Please verify:
- The `existingLabels` variable declared at line 250 is correctly accessible in the assignee-based labeling section (lines 279-330)
- No other duplicate variable declarations exist in the workflow

---

**Reviewers:** Please check the implementation carefully and test the changes if possible.
