### PR TITLE
[Feat] Add `--max-tokens-per-batch` CLI option

### DIFF
--- a/examples/chunked_prefill_test.json
+++ b/examples/chunked_prefill_test.json
@@ -1,0 +1,23 @@
+{
+  "description": "Chunked prefill demonstration: Use --max-tokens-per-batch to control chunking. With default model (max_seq_len=256), use --max-tokens-per-batch 64 to trigger chunking on the ~70 token prompt.",
+  "requests": [
+    {
+      "prompt": "Once upon a time in a magical forest, there lived a little rabbit named Lily. She had soft white fur and bright blue eyes. Every morning, Lily would hop through the meadow to visit her best friend, a wise old owl named Oliver. Oliver lived in a tall oak tree and knew many stories about the forest.",
+      "temperature": 0.7,
+      "top_p": 0.9,
+      "max_tokens": 20
+    },
+    {
+      "prompt": "What is chunked prefill in LLM inference?",
+      "temperature": 0.8,
+      "top_p": 0.9,
+      "max_tokens": 20
+    },
+    {
+      "prompt": "Explain continuous batching briefly.",
+      "temperature": 0.8,
+      "top_p": 0.9,
+      "max_tokens": 20
+    }
+  ]
+}

--- a/include/core/runner.hpp
+++ b/include/core/runner.hpp
@@ -175,7 +175,10 @@ inline BenchmarkResult run_json_batched(LlamaModel           &model,
     Scheduler     scheduler(config);
     BatchedRunner runner(model, tokenizer);
 
-    LOG_INFO("Running in batched mode with max_batch_size=", max_batch_size);
+    LOG_INFO("Running in batched mode with max_batch_size=",
+             max_batch_size,
+             ", max_tokens_per_batch=",
+             max_tokens_per_batch);
 
     BenchmarkMetrics metrics = runner.run_all(requests, scheduler);
 
@@ -207,7 +210,8 @@ inline BenchmarkResult run_json_async(LlamaModel           &model,
     BatchedRunner     runner(model, tokenizer);
     AsyncRequestQueue async_queue;
 
-    LOG_INFO("Running in async mode with max_batch_size=", max_batch_size);
+    LOG_INFO(
+        "Running in async mode with max_batch_size=", max_batch_size, ", max_tokens_per_batch=", max_tokens_per_batch);
 
     // Start producer thread that submits requests with arrival delays
     RequestSubmitter submitter(requests, async_queue);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -24,7 +24,7 @@ public:
     Arg<std::string> prompt{{"-i", "--prompt"}, "Input prompt", ""};
     Arg<std::string> input_json{"--input-json", "Path to JSON file with benchmark requests", ""};
     Arg<int>         max_batch_size{{"-b", "--max-batch-size"}, "Maximum batch size for continuous batching", 1};
-    Arg<int>         max_tokens_per_batch{"--max-tokens-per-batch",
+    Arg<int>         max_tokens_per_batch{{"-bt", "--max-tokens-per-batch"},
                                   "Max tokens per scheduler batch (controls chunked prefill size)",
                                   512};
     Arg<bool>        async_mode{"--async", "Enable async request submission (simulate dynamic arrivals)", false};


### PR DESCRIPTION
<!-- markdownlint-disable -->
## 🎯 Purpose

<!-- What does this PR do? Link related issues here -->

Closes: #44 


## 🧩 Component

<!-- Which component does this PR modify? e.g., PagedAttention, Continuous Batching, Build System -->
Build system 

## 📝 Implementation Summary

<!-- Brief overview of what you implemented and how -->
Add `-bt/--max-tokens-per-batch` CLI option to allow runtime configuration of token budget, enabling chunked prefill testing with the default model (max_seq_len=256).


## 🧪 Testing

<!-- How did you test your changes? -->

```bash
# Build and test commands
make clang
./build/main models/model.bin --input-json examples/chunked_prefill_test.json -b 4 -bt 64
```

**Test Results:**
<!-- Paste test output, benchmark results, or screenshots -->

```
[2026-02-19 16:12:28] [include/utils/argparser.hpp:198] ℹ️ === Parsed Arguments ===
[2026-02-19 16:12:28] [include/utils/argparser.hpp:176] ℹ️   path: models/model.bin
[2026-02-19 16:12:28] [include/utils/argparser.hpp:176] ℹ️   -i, --prompt:  (default)
[2026-02-19 16:12:28] [include/utils/argparser.hpp:176] ℹ️   --input-json: examples/chunked_prefill_test.json
[2026-02-19 16:12:28] [include/utils/argparser.hpp:176] ℹ️   -b, --max-batch-size: 4
[2026-02-19 16:12:28] [include/utils/argparser.hpp:176] ℹ️   -bt, --max-tokens-per-batch: 64
[2026-02-19 16:12:28] [include/utils/argparser.hpp:192] ℹ️   --async: false (default)
[2026-02-19 16:12:28] [include/utils/argparser.hpp:176] ℹ️   -t, --temperature: 1.000000 (default)
[2026-02-19 16:12:28] [include/utils/argparser.hpp:176] ℹ️   -p, --top-p: 0.900000 (default)
[2026-02-19 16:12:28] [include/utils/argparser.hpp:176] ℹ️   -n, --steps: 256 (default)
[2026-02-19 16:12:28] [include/utils/argparser.hpp:192] ℹ️   --without-paged-attn: false (default)
[2026-02-19 16:12:28] [include/utils/argparser.hpp:200] ℹ️ ========================
[2026-02-19 16:12:28] [include/core/model.hpp:121] ℹ️ Loading model: models/model.bin
[2026-02-19 16:12:28] [include/core/model.hpp:139] ℹ️ Config: dim=288 layers=6 heads=6 vocab=32000
[2026-02-19 16:12:28] [include/core/model.hpp:445] ℹ️ Weights shared: lm_head <- token_embedding
[2026-02-19 16:12:28] [src/main.cpp:83] ℹ️ Using PagedAttention (block_size=16)
[2026-02-19 16:12:28] [include/scheduler/block_manager.hpp:23] ℹ️ BlockManager initialized: 256 blocks of size 16
[2026-02-19 16:12:28] [include/core/model.hpp:281] ✅ PagedAttention initialized: 256 blocks × 16 tokens = 4096 total capacity
[2026-02-19 16:12:28] [src/main.cpp:90] ✅ Model loaded successfully
[2026-02-19 16:12:28] [include/core/tokenizer.hpp:33] ℹ️ Loading tokenizer: models/tokenizer.bin
[2026-02-19 16:12:28] [src/main.cpp:98] ✅ Tokenizer loaded successfully
[2026-02-19 16:12:28] [include/core/runner.hpp:188] ✅ Loaded 3 requests from JSON
[2026-02-19 16:12:28] [include/core/runner.hpp:125] ℹ️ Running in batched mode with max_batch_size=4, max_tokens_per_batch=64
[2026-02-19 16:12:28] [include/scheduler/scheduler.hpp:72] ℹ️ Scheduler: Added request 0 to queue
[2026-02-19 16:12:28] [include/scheduler/scheduler.hpp:72] ℹ️ Scheduler: Added request 1 to queue
[2026-02-19 16:12:28] [include/scheduler/scheduler.hpp:72] ℹ️ Scheduler: Added request 2 to queue
[2026-02-19 16:12:28] [include/scheduler/block_manager.hpp:23] ℹ️ BlockManager initialized: 256 blocks of size 16
[2026-02-19 16:12:28] [include/core/model.hpp:281] ✅ PagedAttention initialized: 256 blocks × 16 tokens = 4096 total capacity
[2026-02-19 16:12:28] [include/scheduler/batched_runner.hpp:67] ℹ️ Iteration 0: 1 requests (prefill), 64 tokens
[2026-02-19 16:12:28] [include/scheduler/batched_runner.hpp:67] ℹ️ Iteration 1: 3 requests (prefill), 28 tokens
[2026-02-19 16:12:28] [include/scheduler/batched_runner.hpp:208] ℹ️ Request 0 prefill complete: 72 tokens

[0] [2026-02-19 16:12:28] [include/scheduler/batched_runner.hpp:208] ℹ️ Request 1 prefill complete: 12 tokens

[1] [2026-02-19 16:12:28] [include/scheduler/batched_runner.hpp:208] ℹ️ Request 2 prefill complete: 8 tokens

[2] [2026-02-19 16:12:28] [include/scheduler/batched_runner.hpp:67] ℹ️ Iteration 2: 3 requests (decode), 3 tokens
  A He[2026-02-19 16:12:28] [include/scheduler/batched_runner.hpp:67] ℹ️ Iteration 3: 3 requests (decode), 3 tokens

 m was[2026-02-19 16:12:28] [include/scheduler/batched_runner.hpp:67] ℹ️ Iteration 4: 3 requests (decode), 3 tokens
Oneild trying[2026-02-19 16:12:28] [include/scheduler/batched_runner.hpp:67] ℹ️ Iteration 5: 3 requests (decode), 3 tokens
 day bo to[2026-02-19 16:12:28] [include/scheduler/batched_runner.hpp:67] ℹ️ Iteration 6: 3 requests (decode), 3 tokens
,o find[2026-02-19 16:12:28] [include/scheduler/batched_runner.hpp:67] ℹ️ Iteration 7: 3 requests (decode), 3 tokens
 L, a[2026-02-19 16:12:28] [include/scheduler/batched_runner.hpp:67] ℹ️ Iteration 8: 3 requests (decode), 3 tokens
ily a way[2026-02-19 16:12:28] [include/scheduler/batched_runner.hpp:67] ℹ️ Iteration 9: 3 requests (decode), 3 tokens
 and h to[2026-02-19 16:12:28] [include/scheduler/batched_runner.hpp:67] ℹ️ Iteration 10: 3 requests (decode), 3 tokens
 Oliverurr get[2026-02-19 16:12:28] [include/scheduler/batched_runner.hpp:67] ℹ️ Iteration 11: 3 requests (decode), 3 tokens
 wereicane to[2026-02-19 16:12:28] [include/scheduler/batched_runner.hpp:67] ℹ️ Iteration 12: 3 requests (decode), 3 tokens
 playing would the[2026-02-19 16:12:28] [include/scheduler/batched_runner.hpp:67] ℹ️ Iteration 13: 3 requests (decode), 3 tokens
 a come office[2026-02-19 16:12:28] [include/scheduler/batched_runner.hpp:67] ℹ️ Iteration 14: 3 requests (decode), 3 tokens
 game and,[2026-02-19 16:12:28] [include/scheduler/batched_runner.hpp:67] ℹ️ Iteration 15: 3 requests (decode), 3 tokens
 of take but[2026-02-19 16:12:28] [include/scheduler/batched_runner.hpp:67] ℹ️ Iteration 16: 3 requests (decode), 3 tokens
 hide away he[2026-02-19 16:12:28] [include/scheduler/batched_runner.hpp:67] ℹ️ Iteration 17: 3 requests (decode), 3 tokens
 and your didn[2026-02-19 16:12:28] [include/scheduler/batched_runner.hpp:67] ℹ️ Iteration 18: 3 requests (decode), 3 tokens
 seek dream'[2026-02-19 16:12:28] [include/scheduler/batched_runner.hpp:67] ℹ️ Iteration 19: 3 requests (decode), 3 tokens
.st[2026-02-19 16:12:28] [include/scheduler/batched_runner.hpp:67] ℹ️ Iteration 20: 3 requests (decode), 3 tokens
 L! know[2026-02-19 16:12:28] [include/scheduler/batched_runner.hpp:67] ℹ️ Iteration 21: 3 requests (decode), 3 tokens
ily
[2026-02-19 16:12:28] [include/scheduler/batched_runner.hpp:270] ℹ️ Request 0 finished (MAX_TOKENS): 20 tokens
[2026-02-19 16:12:28] [include/scheduler/block_manager.hpp:170] ℹ️ Freed all blocks for request 0
[2026-02-19 16:12:28] [include/scheduler/scheduler.hpp:151] ℹ️ Scheduler: Request 0 finished


[2026-02-19 16:12:28] [include/scheduler/batched_runner.hpp:270] ℹ️ Request 1 finished (MAX_TOKENS): 20 tokens
[2026-02-19 16:12:28] [include/scheduler/block_manager.hpp:170] ℹ️ Freed all blocks for request 1
[2026-02-19 16:12:28] [include/scheduler/scheduler.hpp:151] ℹ️ Scheduler: Request 1 finished
 how
[2026-02-19 16:12:28] [include/scheduler/batched_runner.hpp:270] ℹ️ Request 2 finished (MAX_TOKENS): 20 tokens
[2026-02-19 16:12:28] [include/scheduler/block_manager.hpp:170] ℹ️ Freed all blocks for request 2
[2026-02-19 16:12:28] [include/scheduler/scheduler.hpp:151] ℹ️ Scheduler: Request 2 finished

========================================
         BENCHMARK RESULTS
========================================
Total requests:         3
Total prompt tokens:    92
Total generated tokens: 60
----------------------------------------
Prefill time:           79.33 ms
Decode time:            116.76 ms
Total time:             196.45 ms
----------------------------------------
Prefill throughput:     1159.75 tokens/sec
Decode throughput:      513.89 tokens/sec
Overall throughput:     773.75 tokens/sec
========================================
[2026-02-19 16:12:28] [include/core/runner.hpp:207] ✅ Benchmark completed
```


## 📚 Documentation

<!-- Did you update documentation? -->


## 👥 Review Notes

<!-- Any specific areas reviewers should focus on? -->
PTAL @RRoundTable :
  Related to PR #43 which already adds --max-tokens-per-batch (without short flag)

---

**Reviewers:** Please check the implementation carefully and test the changes if possible.
